### PR TITLE
Fix element log not working when not cached yet, rewrite plugin

### DIFF
--- a/_build/data/transport.plugins.php
+++ b/_build/data/transport.plugins.php
@@ -7,7 +7,12 @@ $tmp = array(
 		'file' => 'admintools',
 		'description' => '',
 		'events' => array(
-			'OnManagerPageBeforeRender' => array()
+			'OnManagerPageBeforeRender' => array(),
+			'OnChunkFormSave' => array(),
+			'OnSnipFormSave' => array(),
+			'OnTempFormSave' => array(),
+			'OnPluginFormSave' => array(),
+			'OnTVFormSave' => array(),
 		)
 	)
 );

--- a/core/components/admintools/elements/plugins/plugin.admintools.php
+++ b/core/components/admintools/elements/plugins/plugin.admintools.php
@@ -26,6 +26,10 @@ if ($AdminTools instanceof AdminTools) {
             $elementType = 'plugin';
 
             break;
+        case 'OnTVFormSave':
+            $elementType = 'tv';
+
+            break;
     }
 
     if (!empty($elementType)) {

--- a/core/components/admintools/elements/plugins/plugin.admintools.php
+++ b/core/components/admintools/elements/plugins/plugin.admintools.php
@@ -1,25 +1,34 @@
 <?php
-switch ($modx->event->name) {
-    case 'OnManagerPageBeforeRender':
-        $path = $modx->getOption('admintools_core_path', null, $modx->getOption('core_path') . 'components/admintools/').'model/admintools/';
-        $AdminTools = $modx->getService('admintools','AdminTools',$path, $scriptProperties);
-        if ($AdminTools instanceof AdminTools) {
+$path = $modx->getOption('admintools_core_path', null, $modx->getOption('core_path') . 'components/admintools/').'model/admintools/';
+/** @var AdminTools $AdminTools */
+$AdminTools = $modx->getService('admintools','AdminTools',$path, $scriptProperties);
+$elementType = null;
+
+if ($AdminTools instanceof AdminTools) {
+    switch ($modx->event->name) {
+        case 'OnManagerPageBeforeRender':
             $AdminTools->initialize();
-        }
-        break;
-    case 'OnChunkFormSave':
-        $elementType = 'chunk';
-    case 'OnSnipFormSave':
-        if (!isset($elementType)) $elementType = 'snippet';
-    case 'OnTempFormSave':
-        if (!isset($elementType)) $elementType = 'templatet';
-    case 'OnPluginFormSave':
-        if (!isset($elementType)) $elementType = 'plugin';
-        $path = $modx->getOption('admintools_core_path', null, $modx->getOption('core_path') . 'components/admintools/').'model/admintools/';
-        /** @var AdminTools $AdminTools */
-        $AdminTools = $modx->getService('admintools','AdminTools',$path, $scriptProperties);
-        if ($AdminTools instanceof AdminTools) {
-            $AdminTools->updateElementLog($object->toArray());
-        }
-        break;
+
+            break;
+        case 'OnChunkFormSave':
+            $elementType = 'chunk';
+
+            break;
+        case 'OnSnipFormSave':
+            $elementType = 'snippet';
+
+            break;
+        case 'OnTempFormSave':
+            $elementType = 'template';
+
+            break;
+        case 'OnPluginFormSave':
+            $elementType = 'plugin';
+
+            break;
+    }
+
+    if (!empty($elementType)) {
+        $AdminTools->updateElementLog($object->toArray());
+    }
 }

--- a/core/components/admintools/model/admintools/admintools.class.php
+++ b/core/components/admintools/model/admintools/admintools.class.php
@@ -141,11 +141,6 @@ class AdminTools {
     }
 
     public function getElementLog() {
-        $cacheHandler = $this->modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache');
-        $cacheOptions = array(
-            xPDO::OPT_CACHE_KEY => 'admintools/elementlog/',
-            xPDO::OPT_CACHE_HANDLER => $cacheHandler,
-        );
-        return $this->modx->cacheManager->get('element_log', $cacheOptions);
+        return $this->getFromCache('element_log', 'elementlog/');
     }
 }

--- a/core/components/admintools/model/admintools/admintools.class.php
+++ b/core/components/admintools/model/admintools/admintools.class.php
@@ -70,7 +70,7 @@ class AdminTools {
                             $settings = $this->getFromCache('systemSettings', 'favorite_elements/' . $this->modx->user->id);
                             if (empty($settings)) {
                                 $_SESSION['admintools']['systemSettings'] = array('namespace'=>'core','area'=>'');
-                                $this->saveToCache($_SESSION['admintools']['favoriteElements']['systemSettings'], 'favorite_elements/' . $this->modx->user->id);
+                                $this->saveToCache($_SESSION['admintools']['favoriteElements']['systemSettings'], 'systemSettings', 'favorite_elements/' . $this->modx->user->id);
                             } else {
                                 $_SESSION['admintools']['systemSettings'] = $settings;
                             }

--- a/core/components/admintools/processors/mgr/favorites/add.class.php
+++ b/core/components/admintools/processors/mgr/favorites/add.class.php
@@ -4,30 +4,37 @@
  * Add element to favorite list
  */
 class atFavoritesAddElementProcessor extends modProcessor {
-	public $objectType = 'admintools';
-//	public $classKey = '';
-	public $languageTopics = array('admintools:default');
-	//public $permission = 'view';
+    public $objectType = 'admintools';
+//  public $classKey = '';
+    public $languageTopics = array('admintools:default');
+    //public $permission = 'view';
 
+    /**
+     * @return boolean
+     */
+    public function initialize() {
+        $path = $this->modx->getOption('admintools_core_path', null, $this->modx->getOption('core_path') . 'components/admintools/') . 'model/admintools/';
+        $this->modx->getService('admintools', 'AdminTools', $path, array());
 
-	/**
-	 * @return mixed
-	 */
-	public function process() {
+        return ($this->modx->admintools instanceof AdminTools);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function process() {
         $id = (int) $this->getProperty('id');
-        $type = $this->getProperty('type').'s';
-        if (!in_array($id,$_SESSION['admintools']['favoriteElements']['elements'][$type])) $_SESSION['admintools']['favoriteElements']['elements'][$type][] = $id;
+        $type = $this->getProperty('type') . 's';
+        if (!in_array($id, $_SESSION['admintools']['favoriteElements']['elements'][$type])) {
+            $_SESSION['admintools']['favoriteElements']['elements'][$type][] = $id;
+        }
 
-        $cacheHandler = $this->modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache');
-        $cacheElementKey = 'elements';
-        $cacheOptions = array(
-            xPDO::OPT_CACHE_KEY => 'admintools/favorite_elements/'.$this->modx->user->id,
-            xPDO::OPT_CACHE_HANDLER => $cacheHandler,
-        );
-        $this->modx->cacheManager->set($cacheElementKey,  $_SESSION['admintools']['favoriteElements']['elements'], 0, $cacheOptions);
+        $this->modx->admintools->saveToCache($_SESSION['admintools']['favoriteElements']['elements'], 'elements', 'favorite_elements/' . $this->modx->user->id);
+
         @session_write_close();
-        return $this->success('',$_SESSION['admintools']['favoriteElements']['elements']);
-	}
+
+        return $this->success('', $_SESSION['admintools']['favoriteElements']['elements']);
+    }
 
 }
 

--- a/core/components/admintools/processors/mgr/favorites/remove.class.php
+++ b/core/components/admintools/processors/mgr/favorites/remove.class.php
@@ -9,24 +9,29 @@ class atFavoritesRemoveElementProcessor extends modProcessor {
     public $languageTopics = array('admintools:default');
     //public $permission = 'view';
 
+    /**
+     * @return boolean
+     */
+    public function initialize() {
+        $path = $this->modx->getOption('admintools_core_path', null, $this->modx->getOption('core_path') . 'components/admintools/') . 'model/admintools/';
+        $this->modx->getService('admintools', 'AdminTools', $path, array());
+
+        return ($this->modx->admintools instanceof AdminTools);
+    }
 
     /**
      * @return mixed
      */
     public function process() {
         $id = (int) $this->getProperty('id');
-        $type = $this->getProperty('type').'s';
+        $type = $this->getProperty('type') . 's';
         $_SESSION['admintools']['favoriteElements']['elements'][$type] = array_values(array_diff($_SESSION['admintools']['favoriteElements']['elements'][$type],array($id)));
 
-        $cacheHandler = $this->modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache');
-        $cacheElementKey = 'elements';
-        $cacheOptions = array(
-            xPDO::OPT_CACHE_KEY => 'admintools/favorite_elements/'.$this->modx->user->id,
-            xPDO::OPT_CACHE_HANDLER => $cacheHandler,
-        );
-        $this->modx->cacheManager->set($cacheElementKey,  $_SESSION['admintools']['favoriteElements']['elements'], 0, $cacheOptions);
+        $this->modx->admintools->saveToCache($_SESSION['admintools']['favoriteElements']['elements'], 'elements', 'favorite_elements/' . $this->modx->user->id);
+        
         @session_write_close();
-        return $this->success('',$_SESSION['admintools']['favoriteElements']['elements']);
+        
+        return $this->success('', $_SESSION['admintools']['favoriteElements']['elements']);
     }
 
 }

--- a/core/components/admintools/processors/mgr/favorites/savestate.class.php
+++ b/core/components/admintools/processors/mgr/favorites/savestate.class.php
@@ -9,21 +9,26 @@ class atFavoritesSaveStateProcessor extends modProcessor {
 //	public $classKey = '';
 	//public $permission = '';
 
-    public function process()
-    {
+    /**
+     * @return boolean
+     */
+    public function initialize() {
+        $path = $this->modx->getOption('admintools_core_path', null, $this->modx->getOption('core_path') . 'components/admintools/') . 'model/admintools/';
+        $this->modx->getService('admintools', 'AdminTools', $path, array());
+
+        return ($this->modx->admintools instanceof AdminTools);
+    }
+
+    public function process() {
         $state = $this->getProperty('state') == 'true' ? true : false;
         $type = $this->getProperty('type');
         $_SESSION['admintools']['favoriteElements']['states'][$type] = $state;
 
-        $cacheHandler = $this->modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache');
-        $cacheElementKey = 'states';
-        $cacheOptions = array(
-            xPDO::OPT_CACHE_KEY => 'admintools/favorite_elements/'.$this->modx->user->id,
-            xPDO::OPT_CACHE_HANDLER => $cacheHandler,
-        );
-        $this->modx->cacheManager->set($cacheElementKey, $_SESSION['admintools']['favoriteElements']['states'], 0, $cacheOptions);
+        $this->modx->admintools->saveToCache($_SESSION['admintools']['favoriteElements']['states'], 'states', 'favorite_elements/' . $this->modx->user->id);
+        
         @session_write_close();
-        return $this->success('',$_SESSION['admintools']['favoriteElements']['states']);
+
+        return $this->success('', $_SESSION['admintools']['favoriteElements']['states']);
     }
 }
 

--- a/core/components/admintools/processors/mgr/lastedited/getlist.class.php
+++ b/core/components/admintools/processors/mgr/lastedited/getlist.class.php
@@ -9,6 +9,15 @@ class LastEditedElementGetListProcessor extends modProcessor {
 	public $languageTopics = array('admintools:default');
 	//public $permission = 'view';
 
+    /**
+     * @return boolean
+     */
+    public function initialize() {
+        $path = $this->modx->getOption('admintools_core_path', null, $this->modx->getOption('core_path') . 'components/admintools/') . 'model/admintools/';
+        $this->modx->getService('admintools', 'AdminTools', $path, array());
+
+        return ($this->modx->admintools instanceof AdminTools);
+    }
 
 	/**
 	 * @return mixed
@@ -25,17 +34,14 @@ class LastEditedElementGetListProcessor extends modProcessor {
             }
         }
 
-        $sort = $this->getProperty('sort','');
-        $cacheHandler = $this->modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache');
-        $cacheOptions = array(
-            xPDO::OPT_CACHE_KEY => 'admintools/elementlog/',
-            xPDO::OPT_CACHE_HANDLER => $cacheHandler,
-        );
-        $elements = $this->modx->cacheManager->get('element_log', $cacheOptions);
+        $sort = $this->getProperty('sort', '');
+
+        $elements = $this->modx->admintools->getFromCache('element_log', 'elementlog/');
 
         if ($sort) {
             uasort($elements, 'sortEditedElements');
         }
+        
         $data = array();
         if (is_array($elements)) {
             foreach ($elements as $key=>$element) {

--- a/core/components/admintools/processors/mgr/lastedited/remove.class.php
+++ b/core/components/admintools/processors/mgr/lastedited/remove.class.php
@@ -9,6 +9,15 @@ class lastEditedElemntsRemoveProcessor extends modProcessor {
     public $languageTopics = array('admintools:default');
     public $permission = 'remove_led_elements';
 
+    /**
+     * @return boolean
+     */
+    public function initialize() {
+        $path = $this->modx->getOption('admintools_core_path', null, $this->modx->getOption('core_path') . 'components/admintools/') . 'model/admintools/';
+        $this->modx->getService('admintools', 'AdminTools', $path, array());
+
+        return ($this->modx->admintools instanceof AdminTools);
+    }
 
     /**
      * @return mixed
@@ -16,17 +25,14 @@ class lastEditedElemntsRemoveProcessor extends modProcessor {
     public function process() {
         $ids = $this->getProperty('ids');
         $ids = $this->modx->fromJSON($ids);
-        $cacheHandler = $this->modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache');
-        $cacheOptions = array(
-            xPDO::OPT_CACHE_KEY => 'admintools/elementlog/',
-            xPDO::OPT_CACHE_HANDLER => $cacheHandler,
-        );
-        $elements = $this->modx->cacheManager->get('element_log', $cacheOptions);
+        
+        $elements = $this->modx->admintools->getFromCache('element_log', 'elementlog/');
 
         foreach ($ids as $id) {
             unset($elements[$id]);
         }
-        $this->modx->cacheManager->set('element_log',  $elements, 0, $cacheOptions);
+        
+        $this->modx->admintools->saveToCache($elements, 'element_log', 'elementlog/');
 
         return $this->success();
     }

--- a/core/components/admintools/processors/mgr/lastedited/removeall.class.php
+++ b/core/components/admintools/processors/mgr/lastedited/removeall.class.php
@@ -9,18 +9,23 @@ class lastEditedElemntsRemoveAllProcessor extends modProcessor {
     public $languageTopics = array('admintools:default');
     public $permission = 'remove_led_elements';
 
+    /**
+     * @return boolean
+     */
+    public function initialize() {
+        $path = $this->modx->getOption('admintools_core_path', null, $this->modx->getOption('core_path') . 'components/admintools/') . 'model/admintools/';
+        $this->modx->getService('admintools', 'AdminTools', $path, array());
+
+        return ($this->modx->admintools instanceof AdminTools);
+    }
 
     /**
      * @return mixed
      */
     public function process() {
-        $cacheHandler = $this->modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache');
-        $cacheOptions = array(
-            xPDO::OPT_CACHE_KEY => 'admintools/elementlog/',
-            xPDO::OPT_CACHE_HANDLER => $cacheHandler,
-        );
         $elements = array();
-        $this->modx->cacheManager->set('element_log',  $elements, 0, $cacheOptions);
+
+        $this->modx->admintools->saveToCache($elements, 'element_log', 'elementlog/');
 
         return $this->success();
     }

--- a/core/components/admintools/processors/mgr/lastedited/verify.class.php
+++ b/core/components/admintools/processors/mgr/lastedited/verify.class.php
@@ -9,6 +9,15 @@ class lastEditedElementsVerifyProcessor extends modProcessor {
     public $languageTopics = array('admintools:default');
     public $permission = 'remove_led_elements';
 
+    /**
+     * @return boolean
+     */
+    public function initialize() {
+        $path = $this->modx->getOption('admintools_core_path', null, $this->modx->getOption('core_path') . 'components/admintools/') . 'model/admintools/';
+        $this->modx->getService('admintools', 'AdminTools', $path, array());
+
+        return ($this->modx->admintools instanceof AdminTools);
+    }
 
     /**
      * @return mixed
@@ -17,15 +26,12 @@ class lastEditedElementsVerifyProcessor extends modProcessor {
         $id = (int) $this->getProperty('id');
         $type = $this->getProperty('type');
         $classKey = 'mod'.ucfirst($type);
-        if (!$this->modx->getCount($classKey,$id)) {
-            $cacheHandler = $this->modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache');
-            $cacheOptions = array(
-                xPDO::OPT_CACHE_KEY => 'admintools/elementlog/',
-                xPDO::OPT_CACHE_HANDLER => $cacheHandler,
-            );
-            $elements = $this->modx->cacheManager->get('element_log', $cacheOptions);
-            unset($elements[$type.'-'.$id]);
-            $this->modx->cacheManager->set('element_log',  $elements, 0, $cacheOptions);
+
+        if (!$this->modx->getCount($classKey, $id)) {
+            $elements = $this->modx->admintools->getFromCache('element_log', 'elementlog/');
+            unset($elements[$type . '-' . $id]);
+            $this->modx->admintools->saveToCache($elements, 'element_log', 'elementlog/');
+            
             return $this->failure($this->modx->lexicon('admintools_element_nf'));
         }
 

--- a/core/components/admintools/processors/mgr/systemsettings/savestate.class.php
+++ b/core/components/admintools/processors/mgr/systemsettings/savestate.class.php
@@ -6,24 +6,29 @@
 class atSysSettingsSaveStateProcessor extends modProcessor {
 	public $objectType = 'admintools';
     public $languageTopics = array('admintools:default');
-//	public $classKey = '';
-	//public $permission = '';
+    // public $classKey = '';
+	// public $permission = '';
 
-    public function process()
-    {
-        $namespace = $this->getProperty('namespace','');
-        $area = $this->getProperty('area','');
-        $_SESSION['admintools']['systemSettings'] = array('namespace'=>$namespace,'area'=>$area);
+    /**
+     * @return boolean
+     */
+    public function initialize() {
+        $path = $this->modx->getOption('admintools_core_path', null, $this->modx->getOption('core_path') . 'components/admintools/') . 'model/admintools/';
+        $this->modx->getService('admintools', 'AdminTools', $path, array());
 
-        $cacheHandler = $this->modx->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDOFileCache');
-        $cacheElementKey = 'system_settings';
-        $cacheOptions = array(
-            xPDO::OPT_CACHE_KEY => 'admintools/'.$this->modx->user->id,
-            xPDO::OPT_CACHE_HANDLER => $cacheHandler,
-        );
-        $this->modx->cacheManager->set($cacheElementKey,  $_SESSION['admintools']['systemSettings'], 0, $cacheOptions);
+        return ($this->modx->admintools instanceof AdminTools);
+    }
+
+    public function process() {
+        $namespace = $this->getProperty('namespace', '');
+        $area = $this->getProperty('area', '');
+        $_SESSION['admintools']['systemSettings'] = array('namespace' => $namespace, 'area' => $area);
+
+        $this->modx->admintools->saveToCache($_SESSION['admintools']['systemSettings'], 'systemSettings', 'favorite_elements/' . $this->modx->user->id);
+
         @session_write_close();
-        return $this->success('',$_SESSION['admintools']['systemSettings']);
+
+        return $this->success('', $_SESSION['admintools']['systemSettings']);
     }
 }
 


### PR DESCRIPTION
- Fixes the element log not starting to display things when not cached yet, the cache manager will return null and thus is_array() will never be true and no data will be assigned to $elements (which is cached), like this no data will ever find it's way into the cache...the fix is easy, it just assigns $data to $elements when no cache is there yet. I rewrote the caching logic a bit, so the saveToCache() and getFromCache() methods can be used a bit more generic (e.g. also in updateElementLog())...avoid code duplication...
- Rewrote the plugin, avoiding code duplication here as well and added TVs to the element log (were not processed)
- Enhanced build script to activate the necessary system events on setup (only OnManagerPageBeforeRender will be active currently)