### PR TITLE
Fix not working "Remove All" Button for Element Log

### DIFF
--- a/assets/components/admintools/js/mgr/elementlog.js
+++ b/assets/components/admintools/js/mgr/elementlog.js
@@ -4,6 +4,7 @@ AdminTools.window.lastEditedElements = function (config) {
 		config.id = 'admintools-led-window';
 	}
 	Ext.applyIf(config, {
+		url: adminToolsSettings.config.connector_url,
 		title: _('admintools_last_edited'),
 		width: 1000,
 		maxHeight: 800,
@@ -47,7 +48,8 @@ Ext.extend(AdminTools.window.lastEditedElements, MODx.Window, {
 			listeners: {
 				success: {
 					fn: function (r) {
-						this.refresh();
+						// we have to access the grid from the window object this.refresh() won't work
+						this.items.items[0].refresh();
 					}, scope: this
 				}
 			}


### PR DESCRIPTION
The button was throwing an error because the connector url was not defined, fixed that plus fix the non-occuring grid refresh after deleting the log, that didn't work because the success listener was looking for the grid as "this", e.g. this.refresh(), but that's not possible, as this is the window and not the grid...should work now!

Besides that: the "remove_led_elements" permission in the removeall processor has no effect, even when manually created and activated, it doesn't matter if it's active, not active or even existing, the processor will remove the log entries nonetheless, not an issue for me personally, just so you know =) 