### PR TITLE
Fix phptype on field text

### DIFF
--- a/core/components/admintools/model/admintools/mysql/adminnotes.map.inc.php
+++ b/core/components/admintools/model/admintools/mysql/adminnotes.map.inc.php
@@ -29,7 +29,7 @@ $xpdo_meta_map['adminNotes']= array (
     'text' => 
     array (
       'dbtype' => 'text',
-      'phptype' => 'test',
+      'phptype' => 'string',
       'null' => false,
       'default' => '',
     ),

--- a/core/components/admintools/model/schema/admintools.mysql.schema.xml
+++ b/core/components/admintools/model/schema/admintools.mysql.schema.xml
@@ -3,7 +3,7 @@
 
 	<object class="adminNotes" table="admintools_notes" extends="xPDOSimpleObject">
 		<field key="title" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-		<field key="text" dbtype="text" phptype="test" null="false" default="" />
+		<field key="text" dbtype="text" phptype="string" null="false" default="" />
 		<field key="url" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
 		<field key="tags" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
 		<field key="private" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />


### PR DESCRIPTION
modx v2.6.3-pl, php v7.2.5 - не сохранялись заметки, после сохранения вместо текста - "0".