### PR TITLE
Fixed styles of "collapse tree" button for dark theme

### DIFF
--- a/assets/components/admintools/css/mgr/themes/dark.css
+++ b/assets/components/admintools/css/mgr/themes/dark.css
@@ -31,7 +31,11 @@
 .dark-theme  #modx-leftbar-tabs-xsplit .x-layout-mini-east {left: -2px;}
 .dark-theme #modx-leftbar-tabs-xcollapsed .x-layout-mini,
 .dark-theme #modx-leftbar-tabs-xsplit .x-layout-mini {
-	top: 43px !important;
+	top: 42px !important;
+	height: 38px !important;
+	left: 0 !important;
+	opacity: 0.7 !important;
+	background: #202735 !important;
 }
 /*tabs*/
 .dark-theme #modx-leftbar .x-tab-panel-header {background: #202735 !important;}


### PR DESCRIPTION
Before:
![collapse-tree](https://user-images.githubusercontent.com/12523676/96300064-9ff97380-0ffd-11eb-97d6-13dcc2660a1e.png)

After:
![collapse-tree](https://user-images.githubusercontent.com/12523676/96300057-9e2fb000-0ffd-11eb-9978-4906421b310f.gif)